### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub Certifications program",
+        "schedule": "Mondays and Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR addresses issue #6: Missing GitHub Skills Activity

I've added the GitHub Skills activity to the activities list with the following details:
- Description: Learn practical coding and collaboration skills through GitHub Certifications program
- Schedule: Mondays and Thursdays, 3:00 PM - 4:30 PM
- Max participants: 25
- Initially empty participants list

## Why this is important
This was time-sensitive as students need to be able to register for this activity before the end of the week to participate in the GitHub Certifications program, which will help with college applications.

## Testing
- Verified that the activity appears in the list
- Confirmed that students can sign up for this activity